### PR TITLE
Fix for inconsistency in Calendarific API when returning states

### DIFF
--- a/src/Kashyapas.Calendarific.Client/Internal/HolidayMapper.cs
+++ b/src/Kashyapas.Calendarific.Client/Internal/HolidayMapper.cs
@@ -23,9 +23,16 @@ namespace Kashyapas.Calendarific.Client.Internal
                 },
                 Date = new DateTime(year,month,day),
                 Type = source.type,
-                Locations = source.locations,
-                States = source.states,
+                Locations = source.locations
             };
+
+            // 2022-10-25 Oleg Rumiancev: checking is states are string as some returned entries
+            // from Calendarific API return JSON object array instead of string (try country CA - Canada)
+            // non-string state values are ignored
+            if (source.states is string)
+            {
+                destination.States = source.states as string;
+            }
             return destination;
         }
     }

--- a/src/Kashyapas.Calendarific.Client/Models/Holiday.cs
+++ b/src/Kashyapas.Calendarific.Client/Models/Holiday.cs
@@ -10,6 +10,9 @@ namespace Kashyapas.Calendarific.Client.Models
         public DateTime Date { get; set; }
         public string[] Type { get; set; }
         public string Locations { get; set; }
-        public string States { get; set; }
+
+        // 2022-10-25 Oleg Rumiancev: changing from string to object as some returned entries
+        // from Calendarific API return JSON object array instead of string (try country CA - Canada)
+        public object States { get; set; }
     }
 }


### PR DESCRIPTION
Hi!
Sometimes Calendarific API is returning string for "states", and sometimes - JSON array (in case of Holidays for CA - Canada, for year 2022, for example). 

As your ApiHoliday model has states typed as string this fails in the automatic binding somewhere in JSON serialization in Refit package. To avoid serialization failure I've changed states type to object in ApiHoliday and check if it's string in the HolidayMapper.cs before mapping to Holiday type. 

Hope this works for you